### PR TITLE
Missing "exclude" attribute for field "tx_realurl_pathsegment" of "pages_language_overlay"

### DIFF
--- a/cooluri/link.Translate.php
+++ b/cooluri/link.Translate.php
@@ -89,10 +89,10 @@ class Link_Translate {
         if (!empty(self::$conf->cache) && !empty(self::$conf->cache->usecache) && (string)self::$conf->cache->usecache==1) {
             $tp = Link_Func::getTablesPrefix(self::$conf);
             $db = Link_DB::getInstance();
-             
+
             // let's have a look into the cache, we'll look for all possibiltes (meaning trainling slash)
             $tempuri = explode('?',$uri);
-             
+
             $tempuri[0] = Link_Func::prepareLinkForCache($tempuri[0],self::$conf);
 
             $xuri = $tempuri[0];
@@ -419,7 +419,7 @@ class Link_Translate {
             $uriFromCache = $this->getCachedUri($params, $forceUpdate);
             $cacheduri = false;
             $updatecacheid = false;
-            if ($uriFromCache!=null) {
+            if (!is_null($uriFromCache)) {
                 if (is_array($uriFromCache)) {
                     // not good, still needs to be refactored
                     // these paramters are read in the end to
@@ -813,11 +813,11 @@ class Link_Translate {
             }
 
             $path = Link_Func::prepareLinkForCache($path,self::$conf);
-            
+
             foreach ($params as $k=>$v) {
                 unset($originalparams[$k]);
             }
-            
+
             if (!empty($originalparams)) {
                 if (!empty($updatecacheid)) {
                     // first we will update the timestamp (so we will now, when the last uri check was)
@@ -840,7 +840,7 @@ class Link_Translate {
                 }
             }
         }
-        
+
         return $path;
     }
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,55 +1,60 @@
 <?php
-if (!defined ('TYPO3_MODE')) 	die ('Access denied.');
+if (!defined ('TYPO3_MODE')) {
+	die ('Access denied.');
+}
 
 if (TYPO3_MODE == 'BE')	{
-		
 	t3lib_extMgm::addModule('tools','txcooluriM1','',t3lib_extMgm::extPath($_EXTKEY).'mod1/');
-    t3lib_extMgm::addModule('user','txcooluriM2','',t3lib_extMgm::extPath($_EXTKEY).'mod2/');
+	t3lib_extMgm::addModule('user','txcooluriM2','',t3lib_extMgm::extPath($_EXTKEY).'mod2/');
 }
 
 $TCA['pages']['columns']['tx_realurl_pathsegment'] = array(
 	'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_pathsegment',
-    'exclude' => 1,
-	'config' => Array (
+	'exclude' => 1,
+	'config' => array(
 		'type' => 'input',
 		'size' => '30',
 		'max' => '30',
-        'eval' => 'trim,nospace,lower,unique'
-	)
-); 
+		'eval' => 'trim,nospace,lower,unique',
+	),
+);
 
 $TCA['pages']['columns']['tx_cooluri_exclude'] = array(
 	'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_exclude',
-    'exclude' => 1,
-	'config' => Array (
+	'exclude' => 1,
+	'config' => array(
 		'type' => 'check',
-		'default' => '0' 
-	)
-); 
+		'default' => 0,
+	),
+);
 
 $TCA['pages']['columns']['tx_cooluri_excludealways'] = array(
 	'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_excludealways',
-    'exclude' => 1,
-	'config' => Array (
+	'exclude' => 1,
+	'config' => array(
 		'type' => 'check',
-		'default' => '0' 
-	)
+		'default' => 0,
+	),
 );
 
 $TCA['pages_language_overlay']['columns']['tx_realurl_pathsegment'] = array(
-        'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_pathsegment',
-        'config' => Array (
-                'type' => 'input',
-                'size' => '30',
-                'max' => '30',
-                'eval' => 'trim,nospace,lower'
-        )
+	'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_pathsegment',
+	'config' => array(
+		'type' => 'input',
+		'size' => '30',
+		'max' => '30',
+		'eval' => 'trim,nospace,lower',
+	),
 );
 
-t3lib_extMgm::addToAllTCAtypes('pages','tx_realurl_pathsegment,tx_cooluri_exclude,tx_cooluri_excludealways', (t3lib_div::compat_version('4.2') ? '1' : '2'), 'after:nav_title');
-t3lib_extMgm::addToAllTCAtypes('pages','tx_realurl_pathsegment,tx_cooluri_exclude,tx_cooluri_excludealways', (t3lib_div::compat_version('4.2') ? '' : '1,5,') . '4,254', 'after:nav_title');
+t3lib_extMgm::addToAllTCAtypes('pages','tx_realurl_pathsegment,tx_cooluri_exclude,tx_cooluri_excludealways',
+	(t3lib_div::compat_version('4.2') ? '1' : '2'), 'after:nav_title');
+t3lib_extMgm::addToAllTCAtypes('pages','tx_realurl_pathsegment,tx_cooluri_exclude,tx_cooluri_excludealways',
+	(t3lib_div::compat_version('4.2') ? '' : '1,5,') . '4,254', 'after:nav_title');
 
-t3lib_extMgm::addToAllTCAtypes('pages_language_overlay','tx_realurl_pathsegment', (t3lib_div::compat_version('4.2') ? '1' : '2'), 'after:nav_title');
-t3lib_extMgm::addToAllTCAtypes('pages_language_overlay','tx_realurl_pathsegment', (t3lib_div::compat_version('4.2') ? '' : '1,5,') . '4,254', 'after:nav_title');
+t3lib_extMgm::addToAllTCAtypes('pages_language_overlay','tx_realurl_pathsegment',
+	(t3lib_div::compat_version('4.2') ? '1' : '2'), 'after:nav_title');
+t3lib_extMgm::addToAllTCAtypes('pages_language_overlay','tx_realurl_pathsegment',
+	(t3lib_div::compat_version('4.2') ? '' : '1,5,') . '4,254', 'after:nav_title');
 
 ?>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -39,6 +39,7 @@ $TCA['pages']['columns']['tx_cooluri_excludealways'] = array(
 
 $TCA['pages_language_overlay']['columns']['tx_realurl_pathsegment'] = array(
 	'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_pathsegment',
+	'exclude' => 1,
 	'config' => array(
 		'type' => 'input',
 		'size' => '30',


### PR DESCRIPTION
In ext_tables.php, the parameter "exclude" is missing for the field "tx_realurl_pathsegment" of "pages_language_overlay" in the TCA configuration:

``` php
$TCA['pages_language_overlay']['columns']['tx_realurl_pathsegment'] = array(
    'label' => 'LLL:EXT:cooluri/locallang_db.php:pages.tx_cooluri_pathsegment',
    'config' => array(
        'type' => 'input',
        'size' => '30',
        'max' => '30',
        'eval' => 'trim,nospace,lower',
    ),
);
```
