### PR TITLE
[BUGFIX] Process empty URI (site root)

### DIFF
--- a/class.tx_cooluri.php
+++ b/class.tx_cooluri.php
@@ -77,9 +77,6 @@ class tx_cooluri
             t3lib_div::devLog('REQUEST_URI: ' . $paramsinurl, 'CoolUri');
         }
 
-        // check if the only param is the same as the TYPO3 site root
-        if ($paramsinurl == substr(PATH_site, strlen(preg_replace('~/$~', '', $_SERVER['DOCUMENT_ROOT'])))) return;
-
         if ($cond) {
 
             $lt = self::getTranslateInstance();

--- a/cooluri/link.Translate.php
+++ b/cooluri/link.Translate.php
@@ -140,7 +140,6 @@ class Link_Translate {
             $uri = $this->removeFixes($uri);
             // now we remove opening slash
             $uri = preg_replace('~^/*~','',$uri);
-            if (empty($uri)) return;
 
             // first let's look into the caches
             $cachedparams = $this->lookUpInCache($uri);


### PR DESCRIPTION
This makes sure the empty URI (/) is also processed to e.g. allow for enforcing a language path segment.

Fixes #13
