### PR TITLE
Make cooluri compatible with PHP 5.4

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,4 +4,4 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tstemplate.php']['l
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc']['cooluri'] = 'Bednarik\\Cooluri\\Integration\\CoolUri->cool2params';
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['configArrayPostProc']['cooluri'] = 'Bednarik\\Cooluri\\Integration\\CoolUri->goForRedirect';
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['viewOnClickClass']['cooluri'] = \Bednarik\Cooluri\Integration\BackendUtilityHook::class;
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_befunc.php']['viewOnClickClass']['cooluri'] = 'Bednarik\\Cooluri\\Integration\\BackendUtilityHook';


### PR DESCRIPTION
the ::class notation was introduced in PHP 5.5