### PR TITLE
fixes #66017

### DIFF
--- a/Classes/Core/Functions.php
+++ b/Classes/Core/Functions.php
@@ -246,14 +246,10 @@ class Functions {
         }
         $path = preg_replace('~^/~','',$path);
         $path = preg_replace('~^/~','',$path);
-        if (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] == 1) ||
-            isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
-          $protocol = 'https';
-        } else {
-          $protocol = 'http';
-        }
-        $path = $protocol . '://'.$_SERVER['HTTP_HOST'].'/'.$path;
+        $path = '//'.$_SERVER['HTTP_HOST'].'/'.$path;
     }
+    $path = str_replace('http://','//',$path);
+    $path = str_replace('https://','//',$path);
     if (!empty($status)) {
       header('Location: '.$path,true,$status);
     } else {

--- a/Classes/Integration/CoolUri.php
+++ b/Classes/Integration/CoolUri.php
@@ -100,10 +100,13 @@ class CoolUri
                 if (empty(\Bednarik\Cooluri\Core\Translate::$conf->cache->prefix)) {
                     if ($row && !empty($row['redirectTo'])) {
                         $url = $row['redirectTo'] . substr($paramsinurl, 1);
+                        $path = \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($url);
+                        $path = str_replace('http://','//',$path);
+                        $path = str_replace('https://','//',$path);
                         if (empty($row['redirectHttpStatusCode'])) {
-                            header('Location: ' . \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($url));
+                            header('Location: ' . $path);
                         } else {
-                            header('Location: ' . \TYPO3\CMS\Core\Utility\GeneralUtility::locationHeaderUrl($url), true, $row['redirectHttpStatusCode']);
+                            header('Location: ' . $path, true, $row['redirectHttpStatusCode']);
                         }
                         exit;
                     }


### PR DESCRIPTION
https://forge.typo3.org/issues/66017

Implemented fix that uses https://tools.ietf.org/html/rfc3986#section-4.2 compliant URIs like "//www.google.com", thus omitting protocol instead of trying to detect it.
So in all cases where http was already used it is still used, in all scenarios where https was used, this will stick to https. No PHP code necessary, all done on Client Side.