### PR TITLE
Fix  for undefined constant self in PHP 7.2

### DIFF
--- a/Classes/Core/Functions.php
+++ b/Classes/Core/Functions.php
@@ -118,7 +118,7 @@ class Functions {
 
     $pieces = explode('$1',$sql);
     foreach ($pieces as $k=>$v) {
-        $pieces[$k] = preg_replace_callback('~\{([^}]+)\}~',array(self,'replaceParameterInSQL'),$v);
+        $pieces[$k] = preg_replace_callback('~\{([^}]+)\}~',array(__CLASS__,'replaceParameterInSQL'),$v);
     }
     $sql = implode($escapedParam,$pieces);
 


### PR DESCRIPTION
this fixes this kind of errors:
```
PHP Warning: Use of undefined constant self - assumed 'self' ... cooluri/Classes/Core/Functions.php line 121
```